### PR TITLE
fix: correct port in Playwright config from 3000 to 4321

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://127.0.0.1:3000",
+    baseURL: "http://127.0.0.1:4321",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -53,7 +53,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: process.env.CI ? "npm run serve" : "npm run dev",
-    url: "http://127.0.0.1:3000",
+    url: "http://127.0.0.1:4321",
     reuseExistingServer: !process.env.CI,
   },
 });


### PR DESCRIPTION
The dev server (astro dev) and serve script both use port 4321, but the
Playwright config was pointing to port 3000, causing the web server to
time out on startup.

https://claude.ai/code/session_01XXHXYtWgCi7dbYpLZKYC3t